### PR TITLE
update tensorflow api to 1.8

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -224,7 +224,7 @@ def multihead_attention(queries,
         # Causality = Future blinding
         if causality:
             diag_vals = tf.ones_like(outputs[0, :, :]) # (T_q, T_k)
-            tril = tf.contrib.linalg.LinearOperatorTriL(diag_vals).to_dense() # (T_q, T_k)
+            tril = tf.linalg.LinearOperatorLowerTriangular(diag_vals).to_dense() # (T_q, T_k)
             masks = tf.tile(tf.expand_dims(tril, 0), [tf.shape(outputs)[0], 1, 1]) # (h*N, T_q, T_k)
    
             paddings = tf.ones_like(masks)*(-2**32+1)


### PR DESCRIPTION

```
AttributeError: module 'tensorflow.contrib.linalg' has no attribute 'LinearOperatorTriL'
```

## new tensorflow api

https://www.tensorflow.org/api_docs/python/tf/linalg/LinearOperatorLowerTriangular