### PR TITLE
fix the mask problem for multi-head attenion

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -214,7 +214,7 @@ def multihead_attention(queries,
         outputs = outputs / (K_.get_shape().as_list()[-1] ** 0.5)
         
         # Key Masking
-        key_masks = tf.sign(tf.abs(tf.reduce_sum(keys, axis=-1))) # (N, T_k)
+        key_masks = tf.sign(tf.reduce_sum(tf.abs(keys), axis=-1)) # (N, T_k)
         key_masks = tf.tile(key_masks, [num_heads, 1]) # (h*N, T_k)
         key_masks = tf.tile(tf.expand_dims(key_masks, 1), [1, tf.shape(queries)[1], 1]) # (h*N, T_q, T_k)
         
@@ -234,7 +234,7 @@ def multihead_attention(queries,
         outputs = tf.nn.softmax(outputs) # (h*N, T_q, T_k)
          
         # Query Masking
-        query_masks = tf.sign(tf.abs(tf.reduce_sum(queries, axis=-1))) # (N, T_q)
+        query_masks = tf.sign(tf.reduce_sum(tf.abs(queries), axis=-1)) # (N, T_q)
         query_masks = tf.tile(query_masks, [num_heads, 1]) # (h*N, T_q)
         query_masks = tf.tile(tf.expand_dims(query_masks, -1), [1, 1, tf.shape(keys)[1]]) # (h*N, T_q, T_k)
         outputs *= query_masks # broadcasting. (N, T_q, C)

--- a/train.py
+++ b/train.py
@@ -39,7 +39,9 @@ class Graph():
                                       num_units=hp.hidden_units, 
                                       scale=True,
                                       scope="enc_embed")
-                
+
+                key_masks = tf.expand_dims(tf.sign(tf.reduce_sum(tf.abs(self.enc), axis=-1)), -1)
+
                 ## Positional Encoding
                 if hp.sinusoid:
                     self.enc += positional_encoding(self.x,
@@ -54,7 +56,8 @@ class Graph():
                                       zero_pad=False, 
                                       scale=False,
                                       scope="enc_pe")
-                    
+
+                self.enc *= key_masks
                  
                 ## Dropout
                 self.enc = tf.layers.dropout(self.enc, 
@@ -84,7 +87,9 @@ class Graph():
                                       num_units=hp.hidden_units,
                                       scale=True, 
                                       scope="dec_embed")
-                
+
+                key_masks = tf.expand_dims(tf.sign(tf.reduce_sum(tf.abs(self.dec), axis=-1)), -1)
+
                 ## Positional Encoding
                 if hp.sinusoid:
                     self.dec += positional_encoding(self.decoder_inputs,
@@ -100,6 +105,7 @@ class Graph():
                                       zero_pad=False, 
                                       scale=False,
                                       scope="dec_pe")
+                self.dec *= key_masks
                 
                 ## Dropout
                 self.dec = tf.layers.dropout(self.dec, 


### PR DESCRIPTION
We find a small bug for the mask in multi-head attention function.  
The original can not create a right mask because of two reasons:
- First, the addition of position embedding makes the padding embedding in the inputs not all zeros. In this way, we can not get right mask by reduce_sum;  
- Second, to create the mask, the original code do reduce sum first. However, we find there are some possibility that in some positions their embedding sum equal to zero. So we exchange the `abs` and `reduce` sequence to avoid this problem. 