### PR TITLE
Correct key_masks shape

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -103,7 +103,7 @@ def scaled_dot_product_attention(Q, K, V, key_masks,
 def mask(inputs, key_masks=None, type=None):
     """Masks paddings on keys or queries to inputs
     inputs: 3d tensor. (h*N, T_q, T_k)
-    key_masks: 3d tensor. (N, 1, T_k)
+    key_masks: 2d tensor. (N, T_k)
     type: string. "key" | "future"
 
     e.g.,


### PR DESCRIPTION
The mask function defined in the modules.py expects key_masks to be a 2d-tensor of shape (N, T_k), but the comments describe it as a 3d tensor. (N, 1, T_k).
 